### PR TITLE
feat: Add AppBar with menu and settings dialog

### DIFF
--- a/test_models.py
+++ b/test_models.py
@@ -173,7 +173,7 @@ class TestReportGenerator(unittest.TestCase):
         mock_time.now().strftime.return_value = "14:30"
         mock_datetime.datetime = mock_time
         
-        reporte = ReportGenerator.generar_reporte(0, self.operador)
+        reporte = ReportGenerator.generar_reporte(0, self.operador, "Guanta", "PROTECCIÓN CIVIL")
         
         # Verificar contenido del reporte
         self.assertIn("PROTECCIÓN CIVIL MUNICIPIO GUANTA", reporte)
@@ -185,17 +185,17 @@ class TestReportGenerator(unittest.TestCase):
     
     def test_generar_reporte_sin_operador(self):
         """Prueba generación de reporte sin operador."""
-        reporte = ReportGenerator.generar_reporte(0, None)
+        reporte = ReportGenerator.generar_reporte(0, None, "Guanta", "PROTECCIÓN CIVIL")
         self.assertIn("(Sin operador)", reporte)
     
     def test_generar_reporte_indice_invalido(self):
         """Prueba generación con índice de tiempo inválido."""
         # Índice negativo
-        reporte = ReportGenerator.generar_reporte(-1, self.operador)
+        reporte = ReportGenerator.generar_reporte(-1, self.operador, "Guanta", "PROTECCIÓN CIVIL")
         self.assertIn("Cielo despejado", reporte)  # Debe usar índice 0
         
         # Índice muy alto
-        reporte = ReportGenerator.generar_reporte(999, self.operador)
+        reporte = ReportGenerator.generar_reporte(999, self.operador, "Guanta", "PROTECCIÓN CIVIL")
         self.assertIn("Cielo despejado", reporte)  # Debe usar índice 0
     
     def test_markdown_a_textspan(self):

--- a/ui_components.py
+++ b/ui_components.py
@@ -10,7 +10,64 @@ from styles import (
     TextStyles, ButtonStyles, ContainerStyles, InputStyles, 
     Colors, ThemeManager
 )
-from config import EMOJI_TIEMPO, NOMBRES_TIEMPO, get_cargos, JERARQUIAS
+from config import EMOJI_TIEMPO, NOMBRES_TIEMPO, get_cargos, JERARQUIAS, WINDOW_CONFIG
+
+class CustomAppBar:
+    """AppBar personalizada con título y menú de opciones."""
+
+    def __init__(self, app_state: AppState, on_theme_change: Callable, on_manage_operators: Callable, on_show_settings: Callable):
+        self.app_state = app_state
+        self.on_theme_change = on_theme_change
+        self.on_manage_operators = on_manage_operators
+        self.on_show_settings = on_show_settings
+        self.app_bar = self._create_app_bar()
+
+    def _create_app_bar(self) -> ft.AppBar:
+        """Crea el widget AppBar."""
+        is_dark = self.app_state.is_dark_theme
+
+        return ft.AppBar(
+            title=ft.Text(
+                WINDOW_CONFIG["title"],
+                style=TextStyles.title(is_dark)
+            ),
+            bgcolor=ThemeManager.get_page_bgcolor(is_dark),
+            actions=[
+                ft.PopupMenuButton(
+                    items=[
+                        ft.PopupMenuItem(
+                            text="Cambiar Tema",
+                            icon=ThemeManager.get_theme_icon(is_dark),
+                            on_click=lambda _: self.on_theme_change()
+                        ),
+                        ft.PopupMenuItem(
+                            text="Gestionar Operadores",
+                            icon=ft.icons.MANAGE_ACCOUNTS,
+                            on_click=lambda _: self.on_manage_operators()
+                        ),
+                        ft.PopupMenuItem(
+                            text="Ajustes Generales",
+                            icon=ft.icons.SETTINGS,
+                            on_click=lambda _: self.on_show_settings()
+                        )
+                    ]
+                )
+            ]
+        )
+
+    def update_theme(self):
+        """Actualiza el tema del AppBar."""
+        is_dark = self.app_state.is_dark_theme
+
+        # Actualizar título
+        self.app_bar.title.style = TextStyles.subtitle(is_dark)
+
+        # Actualizar color de fondo
+        self.app_bar.bgcolor = ThemeManager.get_page_bgcolor(is_dark)
+
+        # Actualizar ícono del tema en el menú
+        theme_item = self.app_bar.actions[0].items[0]
+        theme_item.icon = ThemeManager.get_theme_icon(is_dark)
 
 class ReportDisplay:
     """Componente para mostrar el reporte generado."""


### PR DESCRIPTION
This commit adds a new `AppBar` to the application with the following features:
- The app title is displayed on the left in bold.
- A `PopupMenuButton` is added to the right with three options:
  - Change Theme: Toggles between light and dark mode.
  - Manage Operators: Opens the operator management dialog.
  - General Settings: Opens a dialog to configure the municipality and department.

The `SettingsDialog` allows the user to change the municipality from a dropdown list populated from `municipios.json` and to change the department, which affects the available roles in the operator management dialog.

The theme changing logic has been refactored to be handled from the new `AppBar` menu.