### PR TITLE
Fix asset path references and module imports

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -8,7 +8,7 @@ import datetime
 import re
 from typing import List, Dict, Optional
 from dataclasses import dataclass
-from config import TIEMPO, EMOJI_TIEMPO, DEPARTAMENTO
+from .config import TIEMPO, EMOJI_TIEMPO, DEPARTAMENTO
 
 @dataclass
 class Operador:
@@ -164,7 +164,7 @@ class ReportGenerator:
     def markdown_a_textspan(texto: str):
         """Convierte texto markdown simple (*texto*) a TextSpans de Flet."""
         import flet as ft
-        from styles import Colors, FONT_FAMILY
+        from .styles import Colors, FONT_FAMILY
         
         patron = r'(\*.*?\*)|([^\*]+)'
         spans = []

--- a/src/styles.py
+++ b/src/styles.py
@@ -3,7 +3,7 @@
 Estilos y temas de la aplicación.
 """
 import flet as ft
-from config import FONT_FAMILY, BORDER_RADIUS
+from .config import FONT_FAMILY, BORDER_RADIUS
 
 class Colors:
     """Paleta de colores de la aplicación."""

--- a/src/ui_components.py
+++ b/src/ui_components.py
@@ -5,12 +5,12 @@ Componentes de interfaz de usuario reutilizables.
 import flet as ft
 import json
 from typing import Callable, Optional, List
-from models import AppState, Operador, ReportGenerator
-from styles import (
+from .models import AppState, Operador, ReportGenerator
+from .styles import (
     TextStyles, ButtonStyles, ContainerStyles, InputStyles, 
     Colors, ThemeManager
 )
-from config import EMOJI_TIEMPO, NOMBRES_TIEMPO, get_cargos, JERARQUIAS, WINDOW_CONFIG
+from .config import EMOJI_TIEMPO, NOMBRES_TIEMPO, get_cargos, JERARQUIAS, WINDOW_CONFIG
 
 class CustomAppBar:
     """AppBar personalizada con título y menú de opciones."""
@@ -27,7 +27,7 @@ class CustomAppBar:
         is_dark = self.app_state.is_dark_theme
 
         return ft.AppBar(
-            leading=ft.Image(src="assets/icon.png", width=30, height=30),
+            leading=ft.Image(src="icon.png", width=30, height=30),
             title=ft.Text(
                 WINDOW_CONFIG["title"],
                 style=TextStyles.subtitle(is_dark)


### PR DESCRIPTION
- Updated the `ft.Image` src path in `src/ui_components.py` to correctly reference the icon from the `assets` directory.
- Corrected the module imports within the `src` directory to use relative paths. This resolves the `ModuleNotFoundError` when running the application.