### PR TITLE
Fix: Prevent cargo list duplication on department change

### DIFF
--- a/src/ui_components.py
+++ b/src/ui_components.py
@@ -323,8 +323,7 @@ class OperatorManagementDialog:
         # Actualiza las opciones de cargo dinámicamente cada vez que se muestra el diálogo.
         # Esto asegura que si el departamento cambió en los Ajustes, se refleje aquí.
         cargos = get_cargos(self.app_state.departamento)
-        self.cargo_dropdown.options.clear()
-        self.cargo_dropdown.options.extend([ft.dropdown.Option(cargo) for cargo in cargos])
+        self.cargo_dropdown.options = [ft.dropdown.Option(cargo) for cargo in cargos]
         # Asegurarse de que el valor seleccionado sea válido
         if self.cargo_dropdown.value not in cargos:
             self.cargo_dropdown.value = cargos[0] if cargos else None


### PR DESCRIPTION
The list of cargos in the Operator Management dialog was being duplicated each time the department was changed in the settings.

This was happening because the `show` method of the `OperatorManagementDialog` was using `clear()` and `extend()` to update the dropdown options. This was redundant with the update logic in `_on_settings_save` and was causing the duplication.

The fix replaces the `clear()` and `extend()` calls with a direct assignment (`=`), which is a more robust way to update the dropdown options and solves the duplication issue.