### PR TITLE
Refactor: Centralize cargo dropdown update logic

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -136,10 +136,6 @@ class WeatherReportApp:
     def _on_settings_save(self):
         """Se ejecuta cuando se guardan los ajustes."""
         self.report_display.update_report()
-        cargos = get_cargos(self.app_state.departamento)
-        self.operator_management.cargo_dropdown.options = [ft.dropdown.Option(c) for c in cargos]
-        if self.operator_management.cargo_dropdown.value not in cargos:
-            self.operator_management.cargo_dropdown.value = cargos[0] if cargos else None
         self.page.update()
 
     def _initial_update(self):


### PR DESCRIPTION
This commit refactors the way the 'cargo' dropdown is updated to prevent duplication issues.

Previously, the dropdown's options were being updated in two places:
1. In `_on_settings_save` when the department was changed.
2. In `OperatorManagementDialog.show` when the dialog was opened.

This redundancy was causing the list of cargos to duplicate when the main report data (operator or weather) was changed, triggering a UI update.

The fix removes the update logic from `_on_settings_save`, making `OperatorManagementDialog.show` the single source of truth for updating the cargo list. This ensures the list is always fresh and correct when the dialog is displayed.

This change fixes the following bugs:
- Cargo list duplicating when the department is changed.
- Cargo list duplicating when the main operator or weather status is changed.